### PR TITLE
Find matching element across HTML versions

### DIFF
--- a/analyze_structure.py
+++ b/analyze_structure.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+import re
+from lxml import html
+import sys
+
+def analyze_html_structure(file_path):
+    """Analyze HTML structure to understand the layout"""
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+        
+        # Parse HTML
+        doc = html.fromstring(content)
+        
+        print(f"Analyzing {file_path}...")
+        
+        # Find all forms
+        forms = doc.xpath("//form")
+        print(f"Found {len(forms)} forms")
+        
+        for i, form in enumerate(forms):
+            print(f"\nForm {i+1}:")
+            print(f"  ID: {form.get('id', 'No ID')}")
+            print(f"  Class: {form.get('class', 'No class')}")
+            
+            # Find all divs within this form
+            divs = form.xpath(".//div")
+            print(f"  Contains {len(divs)} divs")
+            
+            # Find all links within this form
+            links = form.xpath(".//a")
+            print(f"  Contains {len(links)} links")
+            
+            for j, link in enumerate(links):
+                print(f"    Link {j+1}: {link.text_content().strip()[:50]}...")
+                print(f"      href: {link.get('href', 'No href')}")
+        
+        # Look for search-related forms specifically
+        search_forms = doc.xpath("//form[contains(@class, 'search') or contains(@id, 'search')]")
+        print(f"\nFound {len(search_forms)} search-related forms")
+        
+        for i, form in enumerate(search_forms):
+            print(f"\nSearch Form {i+1}:")
+            print(f"  ID: {form.get('id', 'No ID')}")
+            print(f"  Class: {form.get('class', 'No class')}")
+            
+            # Get the XPath to this form
+            form_xpath = doc.getpath(form)
+            print(f"  XPath: {form_xpath}")
+            
+            # Find all links within this form
+            links = form.xpath(".//a")
+            print(f"  Contains {len(links)} links")
+            
+            for j, link in enumerate(links):
+                link_xpath = doc.getpath(link)
+                print(f"    Link {j+1}: {link.text_content().strip()[:50]}...")
+                print(f"      XPath: {link_xpath}")
+                print(f"      href: {link.get('href', 'No href')}")
+        
+        return doc
+        
+    except Exception as e:
+        print(f"Error processing {file_path}: {e}")
+        return None
+
+def find_similar_elements(old_doc, new_doc):
+    """Find similar elements between old and new documents"""
+    print("\nLooking for similar elements...")
+    
+    # Find all forms in both documents
+    old_forms = old_doc.xpath("//form")
+    new_forms = new_doc.xpath("//form")
+    
+    print(f"Old document has {len(old_forms)} forms")
+    print(f"New document has {len(new_forms)} forms")
+    
+    # Look for search forms specifically
+    old_search_forms = old_doc.xpath("//form[contains(@class, 'search') or contains(@id, 'search')]")
+    new_search_forms = new_doc.xpath("//form[contains(@class, 'search') or contains(@id, 'search')]")
+    
+    print(f"Old document has {len(old_search_forms)} search forms")
+    print(f"New document has {len(new_search_forms)} search forms")
+    
+    if old_search_forms and new_search_forms:
+        old_form = old_search_forms[0]
+        new_form = new_search_forms[0]
+        
+        print(f"\nOld search form XPath: {old_doc.getpath(old_form)}")
+        print(f"New search form XPath: {new_doc.getpath(new_form)}")
+        
+        # Find links in both forms
+        old_links = old_form.xpath(".//a")
+        new_links = new_form.xpath(".//a")
+        
+        print(f"Old search form has {len(old_links)} links")
+        print(f"New search form has {len(new_links)} links")
+        
+        if old_links and new_links:
+            old_link = old_links[0]
+            new_link = new_links[0]
+            
+            print(f"\nOld first link:")
+            print(f"  Text: '{old_link.text_content().strip()}'")
+            print(f"  href: {old_link.get('href', 'No href')}")
+            print(f"  XPath: {old_doc.getpath(old_link)}")
+            
+            print(f"\nNew first link:")
+            print(f"  Text: '{new_link.text_content().strip()}'")
+            print(f"  href: {new_link.get('href', 'No href')}")
+            print(f"  XPath: {new_doc.getpath(new_link)}")
+            
+            return new_doc.getpath(new_link)
+    
+    return None
+
+if __name__ == "__main__":
+    old_file = "/workspace/Microsoft_old.html"
+    new_file = "/workspace/Microsoft_new.html"
+    
+    print("=== Analyzing Old File ===")
+    old_doc = analyze_html_structure(old_file)
+    
+    print("\n=== Analyzing New File ===")
+    new_doc = analyze_html_structure(new_file)
+    
+    if old_doc and new_doc:
+        result = find_similar_elements(old_doc, new_doc)
+        if result:
+            print(f"\nFinal result: {result}")
+        else:
+            print("\nFinal result: null")
+    else:
+        print("\nFinal result: null")

--- a/find_all_links.py
+++ b/find_all_links.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+import re
+from lxml import html, etree
+import sys
+
+def get_xpath(element):
+    """Generate XPath for an element"""
+    path = []
+    while element is not None:
+        tag = element.tag
+        if tag is None:
+            break
+        
+        # Get position among siblings with same tag
+        siblings = element.getparent()
+        if siblings is not None:
+            same_tag_siblings = [s for s in siblings if s.tag == tag]
+            if len(same_tag_siblings) > 1:
+                position = same_tag_siblings.index(element) + 1
+                path.insert(0, f"{tag}[{position}]")
+            else:
+                path.insert(0, tag)
+        else:
+            path.insert(0, tag)
+        
+        element = element.getparent()
+    
+    return "/" + "/".join(path)
+
+def find_all_links_and_forms(file_path):
+    """Find all links and forms in the file"""
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+        
+        # Parse HTML
+        doc = html.fromstring(content)
+        
+        print(f"Analyzing {file_path}...")
+        
+        # Find all forms
+        forms = doc.xpath("//form")
+        print(f"Found {len(forms)} forms")
+        
+        for i, form in enumerate(forms):
+            print(f"\nForm {i+1}:")
+            print(f"  ID: {form.get('id', 'No ID')}")
+            print(f"  Class: {form.get('class', 'No class')}")
+            print(f"  XPath: {get_xpath(form)}")
+            
+            # Find all divs within this form
+            divs = form.xpath(".//div")
+            print(f"  Contains {len(divs)} divs")
+            
+            # Find all links within this form
+            links = form.xpath(".//a")
+            print(f"  Contains {len(links)} links")
+            
+            for j, link in enumerate(links):
+                print(f"    Link {j+1}: {link.text_content().strip()[:50]}...")
+                print(f"      href: {link.get('href', 'No href')}")
+                print(f"      XPath: {get_xpath(link)}")
+        
+        # Find all links in the document
+        all_links = doc.xpath("//a")
+        print(f"\nFound {len(all_links)} total links in document")
+        
+        # Show first 10 links
+        for i, link in enumerate(all_links[:10]):
+            print(f"  Link {i+1}: {link.text_content().strip()[:50]}...")
+            print(f"    href: {link.get('href', 'No href')}")
+            print(f"    XPath: {get_xpath(link)}")
+        
+        return doc
+        
+    except Exception as e:
+        print(f"Error processing {file_path}: {e}")
+        return None
+
+def try_original_xpath(doc, xpath):
+    """Try to find element using the original XPath"""
+    try:
+        elements = doc.xpath(xpath)
+        if elements:
+            element = elements[0]
+            print(f"Found element with original XPath:")
+            print(f"  Tag: {element.tag}")
+            print(f"  Text: {element.text_content().strip()}")
+            print(f"  Attributes: {element.attrib}")
+            return element
+        else:
+            print(f"No element found with XPath: {xpath}")
+            return None
+    except Exception as e:
+        print(f"Error with XPath {xpath}: {e}")
+        return None
+
+if __name__ == "__main__":
+    old_file = "/workspace/Microsoft_old.html"
+    new_file = "/workspace/Microsoft_new.html"
+    original_xpath = "/html[1]/body[1]/div[1]/form[1]/div[2]/div[1]/div[1]/a[1]"
+    
+    print("=== Analyzing Old File ===")
+    old_doc = find_all_links_and_forms(old_file)
+    
+    print("\n=== Trying Original XPath on Old File ===")
+    old_element = try_original_xpath(old_doc, original_xpath)
+    
+    print("\n=== Analyzing New File ===")
+    new_doc = find_all_links_and_forms(new_file)
+    
+    print("\n=== Trying Original XPath on New File ===")
+    new_element = try_original_xpath(new_doc, original_xpath)
+    
+    if old_element and new_element:
+        print(f"\nBoth files have elements matching the original XPath")
+        print(f"Old element: {old_element.text_content().strip()}")
+        print(f"New element: {new_element.text_content().strip()}")
+        print(f"Final result: {original_xpath}")
+    elif old_element:
+        print(f"\nOnly old file has element matching the original XPath")
+        print(f"Final result: null")
+    else:
+        print(f"\nNeither file has element matching the original XPath")
+        print(f"Final result: null")

--- a/find_xpath.py
+++ b/find_xpath.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+import re
+from lxml import html
+import sys
+
+def find_xpath_element(file_path, xpath):
+    """Find element using XPath in HTML file"""
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+        
+        # Parse HTML
+        doc = html.fromstring(content)
+        
+        # Find element using XPath
+        elements = doc.xpath(xpath)
+        
+        if elements:
+            element = elements[0]
+            print(f"Found element in {file_path}:")
+            print(f"Tag: {element.tag}")
+            print(f"Text: {element.text_content().strip()}")
+            print(f"Attributes: {element.attrib}")
+            return element
+        else:
+            print(f"No element found with XPath: {xpath}")
+            return None
+            
+    except Exception as e:
+        print(f"Error processing {file_path}: {e}")
+        return None
+
+def find_matching_element(old_file, new_file, old_xpath):
+    """Find matching element in new file based on old element"""
+    # First find the element in old file
+    old_element = find_xpath_element(old_file, old_xpath)
+    if not old_element:
+        return None
+    
+    print(f"\nLooking for matching element in {new_file}...")
+    
+    # Get characteristics of the old element
+    old_tag = old_element.tag
+    old_text = old_element.text_content().strip()
+    old_attrs = old_element.attrib
+    
+    print(f"Old element characteristics:")
+    print(f"  Tag: {old_tag}")
+    print(f"  Text: '{old_text}'")
+    print(f"  Attributes: {old_attrs}")
+    
+    # Parse new file
+    try:
+        with open(new_file, 'r', encoding='utf-8') as f:
+            new_content = f.read()
+        
+        new_doc = html.fromstring(new_content)
+        
+        # Look for similar elements
+        # Try to find elements with same tag and similar text
+        similar_elements = []
+        
+        # Find all elements with same tag
+        all_elements = new_doc.xpath(f"//{old_tag}")
+        
+        for elem in all_elements:
+            elem_text = elem.text_content().strip()
+            # Check if text is similar or if it's a link with similar href
+            if (elem_text == old_text or 
+                (old_tag == 'a' and 'href' in elem.attrib and 'href' in old_attrs and 
+                 elem.attrib.get('href') == old_attrs.get('href'))):
+                similar_elements.append(elem)
+        
+        if similar_elements:
+            best_match = similar_elements[0]
+            print(f"\nFound {len(similar_elements)} potential matches")
+            print(f"Best match:")
+            print(f"  Tag: {best_match.tag}")
+            print(f"  Text: '{best_match.text_content().strip()}'")
+            print(f"  Attributes: {best_match.attrib}")
+            
+            # Generate XPath for the best match
+            xpath = new_doc.getpath(best_match)
+            print(f"\nGenerated XPath: {xpath}")
+            return xpath
+        else:
+            print("No matching element found")
+            return None
+            
+    except Exception as e:
+        print(f"Error processing {new_file}: {e}")
+        return None
+
+if __name__ == "__main__":
+    old_file = "/workspace/Microsoft_old.html"
+    new_file = "/workspace/Microsoft_new.html"
+    old_xpath = "/html[1]/body[1]/div[1]/form[1]/div[2]/div[1]/div[1]/a[1]"
+    
+    result = find_matching_element(old_file, new_file, old_xpath)
+    if result:
+        print(f"\nFinal result: {result}")
+    else:
+        print("\nFinal result: null")

--- a/find_xpath_fixed.py
+++ b/find_xpath_fixed.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+import re
+from lxml import html, etree
+import sys
+
+def get_xpath(element):
+    """Generate XPath for an element"""
+    path = []
+    while element is not None:
+        tag = element.tag
+        if tag is None:
+            break
+        
+        # Get position among siblings with same tag
+        siblings = element.getparent()
+        if siblings is not None:
+            same_tag_siblings = [s for s in siblings if s.tag == tag]
+            if len(same_tag_siblings) > 1:
+                position = same_tag_siblings.index(element) + 1
+                path.insert(0, f"{tag}[{position}]")
+            else:
+                path.insert(0, tag)
+        else:
+            path.insert(0, tag)
+        
+        element = element.getparent()
+    
+    return "/" + "/".join(path)
+
+def analyze_html_structure(file_path):
+    """Analyze HTML structure to understand the layout"""
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+        
+        # Parse HTML
+        doc = html.fromstring(content)
+        
+        print(f"Analyzing {file_path}...")
+        
+        # Find all forms
+        forms = doc.xpath("//form")
+        print(f"Found {len(forms)} forms")
+        
+        for i, form in enumerate(forms):
+            print(f"\nForm {i+1}:")
+            print(f"  ID: {form.get('id', 'No ID')}")
+            print(f"  Class: {form.get('class', 'No class')}")
+            
+            # Find all divs within this form
+            divs = form.xpath(".//div")
+            print(f"  Contains {len(divs)} divs")
+            
+            # Find all links within this form
+            links = form.xpath(".//a")
+            print(f"  Contains {len(links)} links")
+            
+            for j, link in enumerate(links):
+                print(f"    Link {j+1}: {link.text_content().strip()[:50]}...")
+                print(f"      href: {link.get('href', 'No href')}")
+                print(f"      XPath: {get_xpath(link)}")
+        
+        # Look for search-related forms specifically
+        search_forms = doc.xpath("//form[contains(@class, 'search') or contains(@id, 'search')]")
+        print(f"\nFound {len(search_forms)} search-related forms")
+        
+        for i, form in enumerate(search_forms):
+            print(f"\nSearch Form {i+1}:")
+            print(f"  ID: {form.get('id', 'No ID')}")
+            print(f"  Class: {form.get('class', 'No class')}")
+            
+            # Get the XPath to this form
+            form_xpath = get_xpath(form)
+            print(f"  XPath: {form_xpath}")
+            
+            # Find all links within this form
+            links = form.xpath(".//a")
+            print(f"  Contains {len(links)} links")
+            
+            for j, link in enumerate(links):
+                link_xpath = get_xpath(link)
+                print(f"    Link {j+1}: {link.text_content().strip()[:50]}...")
+                print(f"      XPath: {link_xpath}")
+                print(f"      href: {link.get('href', 'No href')}")
+        
+        return doc
+        
+    except Exception as e:
+        print(f"Error processing {file_path}: {e}")
+        return None
+
+def find_similar_elements(old_doc, new_doc):
+    """Find similar elements between old and new documents"""
+    print("\nLooking for similar elements...")
+    
+    # Find all forms in both documents
+    old_forms = old_doc.xpath("//form")
+    new_forms = new_doc.xpath("//form")
+    
+    print(f"Old document has {len(old_forms)} forms")
+    print(f"New document has {len(new_forms)} forms")
+    
+    # Look for search forms specifically
+    old_search_forms = old_doc.xpath("//form[contains(@class, 'search') or contains(@id, 'search')]")
+    new_search_forms = new_doc.xpath("//form[contains(@class, 'search') or contains(@id, 'search')]")
+    
+    print(f"Old document has {len(old_search_forms)} search forms")
+    print(f"New document has {len(new_search_forms)} search forms")
+    
+    if old_search_forms and new_search_forms:
+        old_form = old_search_forms[0]
+        new_form = new_search_forms[0]
+        
+        print(f"\nOld search form XPath: {get_xpath(old_form)}")
+        print(f"New search form XPath: {get_xpath(new_form)}")
+        
+        # Find links in both forms
+        old_links = old_form.xpath(".//a")
+        new_links = new_form.xpath(".//a")
+        
+        print(f"Old search form has {len(old_links)} links")
+        print(f"New search form has {len(new_links)} links")
+        
+        if old_links and new_links:
+            old_link = old_links[0]
+            new_link = new_links[0]
+            
+            print(f"\nOld first link:")
+            print(f"  Text: '{old_link.text_content().strip()}'")
+            print(f"  href: {old_link.get('href', 'No href')}")
+            print(f"  XPath: {get_xpath(old_link)}")
+            
+            print(f"\nNew first link:")
+            print(f"  Text: '{new_link.text_content().strip()}'")
+            print(f"  href: {new_link.get('href', 'No href')}")
+            print(f"  XPath: {get_xpath(new_link)}")
+            
+            return get_xpath(new_link)
+    
+    return None
+
+if __name__ == "__main__":
+    old_file = "/workspace/Microsoft_old.html"
+    new_file = "/workspace/Microsoft_new.html"
+    
+    print("=== Analyzing Old File ===")
+    old_doc = analyze_html_structure(old_file)
+    
+    print("\n=== Analyzing New File ===")
+    new_doc = analyze_html_structure(new_file)
+    
+    if old_doc and new_doc:
+        result = find_similar_elements(old_doc, new_doc)
+        if result:
+            print(f"\nFinal result: {result}")
+        else:
+            print("\nFinal result: null")
+    else:
+        print("\nFinal result: null")


### PR DESCRIPTION
Introduce Python scripts to parse HTML, analyze document structure, and attempt to locate elements using a given XPath.

The scripts were created to systematically analyze the provided HTML files and validate the given XPath, as the initial `ripgrep` attempts were insufficient for the complex HTML structure. This led to the conclusion that the original XPath did not match any element in either the old or new HTML files.

---
<a href="https://cursor.com/background-agent?bcId=bc-82c7827b-effd-4e59-8a8a-bad69d0f662f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-82c7827b-effd-4e59-8a8a-bad69d0f662f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

